### PR TITLE
Add domains for Amazon DE, IT, BE, FR, PL, NL, and ES to the manifest file

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,17 @@
   },
   "content_scripts": [
     {
-      "matches": [ "https://sellercentral.amazon.co.uk/*", "https://sellercentral-europe.amazon.com/*" ],
+      "matches": [ 
+        "https://sellercentral.amazon.co.uk/*", 
+        "https://sellercentral-europe.amazon.com/*", 
+        "https://sellercentral.amazon.com.be/*",
+        "https://sellercentral.amazon.de/*",
+        "https://sellercentral.amazon.fr/*",
+        "https://sellercentral.amazon.it/*",
+        "https://sellercentral.amazon.es/*",
+        "https://sellercentral.amazon.nl/*",
+        "https://sellercentral.amazon.pl/*"
+      ],
       "js": [ "scripts/amazon.js" ]
     }
   ]


### PR DESCRIPTION
This pull request updates the manifest file to include support for additional Amazon markets. Specifically, the domains for Germany (DE), Italy (IT), Belgium (BE), France (FR), Poland (PL), the Netherlands (NL), and Spain (ES) have been added.